### PR TITLE
Twitch動画検索機能の実装

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/example/project/feature/video_search/VideoSearchIntent.kt
+++ b/composeApp/src/commonMain/kotlin/org/example/project/feature/video_search/VideoSearchIntent.kt
@@ -60,9 +60,9 @@ sealed interface VideoSearchIntent {
     data class ChangeSearchMode(val mode: SearchMode) : VideoSearchIntent
 
     /**
-     * Intent to toggle a video service selection
+     * Intent to select a video service (single selection)
      */
-    data class ToggleService(val service: VideoServiceType) : VideoSearchIntent
+    data class SelectService(val service: VideoServiceType) : VideoSearchIntent
 }
 
 /**

--- a/composeApp/src/commonMain/kotlin/org/example/project/feature/video_search/VideoSearchUiState.kt
+++ b/composeApp/src/commonMain/kotlin/org/example/project/feature/video_search/VideoSearchUiState.kt
@@ -1,8 +1,10 @@
 package org.example.project.feature.video_search
 
 import kotlin.time.ExperimentalTime
+import kotlinx.datetime.DateTimeUnit
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.TimeZone
+import kotlinx.datetime.minus
 import kotlinx.datetime.toLocalDateTime
 import org.example.project.domain.model.SearchResult
 import org.example.project.domain.model.VideoServiceType
@@ -21,9 +23,10 @@ constructor(
     val searchError: String? = null,
     val searchNextPageToken: String? = null,
     val selectedDate: LocalDate = kotlin.time.Clock.System.now()
-        .toLocalDateTime(TimeZone.currentSystemDefault()).date,
+        .toLocalDateTime(TimeZone.currentSystemDefault()).date
+        .minus(1, DateTimeUnit.DAY),
     val searchMode: SearchMode = SearchMode.KEYWORD,
-    val selectedServices: Set<VideoServiceType> = setOf(VideoServiceType.YOUTUBE),
+    val selectedService: VideoServiceType = VideoServiceType.YOUTUBE,
 )
 
 /**

--- a/composeApp/src/commonMain/kotlin/org/example/project/feature/video_search/VideoSearchViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/example/project/feature/video_search/VideoSearchViewModel.kt
@@ -58,7 +58,7 @@ class VideoSearchViewModel(
             VideoSearchIntent.ClearSearchResults -> clearSearchResults()
             is VideoSearchIntent.ChangeSelectedDate -> changeSelectedDate(intent.date)
             is VideoSearchIntent.ChangeSearchMode -> changeSearchMode(intent.mode)
-            is VideoSearchIntent.ToggleService -> toggleService(intent.service)
+            is VideoSearchIntent.SelectService -> selectService(intent.service)
         }
     }
 
@@ -96,13 +96,21 @@ class VideoSearchViewModel(
 
         viewModelScope.launch {
             try {
+                // For Twitch, use channelId parameter; for YouTube, use query
+                val channelId = if (currentState.selectedService == VideoServiceType.TWITCH) {
+                    query
+                } else {
+                    null
+                }
+
                 val result = videoSearchUseCase.searchVideos(
                     query = query,
                     preferArchived = true,
                     publishedAfter = startOfDay,
                     publishedBefore = endOfDay,
                     order = SearchOrder.VIEW_COUNT,
-                    targetServices = currentState.selectedServices,
+                    targetServices = setOf(currentState.selectedService),
+                    channelId = channelId,
                 )
 
                 result.fold(
@@ -148,6 +156,13 @@ class VideoSearchViewModel(
 
         viewModelScope.launch {
             try {
+                // For Twitch, use channelId parameter; for YouTube, use query
+                val channelId = if (currentState.selectedService == VideoServiceType.TWITCH) {
+                    currentState.searchQuery
+                } else {
+                    null
+                }
+
                 val result = videoSearchUseCase.loadMoreResults(
                     query = currentState.searchQuery,
                     nextPageToken = nextPageToken,
@@ -155,7 +170,8 @@ class VideoSearchViewModel(
                     publishedAfter = startOfDay,
                     publishedBefore = endOfDay,
                     order = SearchOrder.VIEW_COUNT,
-                    targetServices = currentState.selectedServices,
+                    targetServices = setOf(currentState.selectedService),
+                    channelId = channelId,
                 )
 
                 result.fold(
@@ -227,17 +243,15 @@ class VideoSearchViewModel(
         _uiState.value = _uiState.value.copy(searchMode = mode)
     }
 
-    private fun toggleService(service: VideoServiceType) {
-        val currentServices = _uiState.value.selectedServices
-        val newServices = if (currentServices.contains(service)) {
-            if (currentServices.size > 1) {
-                currentServices - service
-            } else {
-                currentServices // Keep at least one service selected
-            }
-        } else {
-            currentServices + service
+    private fun selectService(service: VideoServiceType) {
+        // When switching to Twitch, force search mode to CHANNEL_NAME
+        val newSearchMode = when (service) {
+            VideoServiceType.YOUTUBE -> _uiState.value.searchMode // Keep current mode for YouTube
+            VideoServiceType.TWITCH -> SearchMode.CHANNEL_NAME // Force CHANNEL_NAME for Twitch
         }
-        _uiState.value = _uiState.value.copy(selectedServices = newServices)
+        _uiState.value = _uiState.value.copy(
+            selectedService = service,
+            searchMode = newSearchMode,
+        )
     }
 }

--- a/composeApp/src/commonMain/kotlin/org/example/project/feature/video_search/ui/VideoSearchContent.kt
+++ b/composeApp/src/commonMain/kotlin/org/example/project/feature/video_search/ui/VideoSearchContent.kt
@@ -20,13 +20,13 @@ import androidx.compose.material.icons.filled.CalendarToday
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
-import androidx.compose.material3.Checkbox
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -57,7 +57,7 @@ fun VideoSearchContent(
     hasMoreResults: Boolean,
     selectedDate: LocalDate,
     searchMode: SearchMode,
-    selectedServices: Set<VideoServiceType>,
+    selectedService: VideoServiceType,
     onInputTextChange: (String) -> Unit,
     onExecuteSearch: () -> Unit,
     onSelectResult: (SearchResult) -> Unit,
@@ -65,7 +65,7 @@ fun VideoSearchContent(
     onClearError: () -> Unit,
     onDateChange: (LocalDate) -> Unit,
     onSearchModeChange: (SearchMode) -> Unit,
-    onToggleService: (VideoServiceType) -> Unit,
+    onSelectService: (VideoServiceType) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val keyboardController = LocalSoftwareKeyboardController.current
@@ -114,7 +114,7 @@ fun VideoSearchContent(
             verticalAlignment = Alignment.CenterVertically,
         ) {
             Text(
-                text = "Services:",
+                text = "Service:",
                 style = MaterialTheme.typography.bodyMedium,
                 fontWeight = FontWeight.Medium,
             )
@@ -122,35 +122,37 @@ fun VideoSearchContent(
                 horizontalArrangement = Arrangement.spacedBy(4.dp),
                 verticalAlignment = Alignment.CenterVertically,
             ) {
-                Checkbox(
-                    checked = selectedServices.contains(VideoServiceType.YOUTUBE),
-                    onCheckedChange = { onToggleService(VideoServiceType.YOUTUBE) },
+                RadioButton(
+                    selected = selectedService == VideoServiceType.YOUTUBE,
+                    onClick = { onSelectService(VideoServiceType.YOUTUBE) },
                 )
                 Text("YouTube")
                 Spacer(modifier = Modifier.width(8.dp))
-                Checkbox(
-                    checked = selectedServices.contains(VideoServiceType.TWITCH),
-                    onCheckedChange = { onToggleService(VideoServiceType.TWITCH) },
+                RadioButton(
+                    selected = selectedService == VideoServiceType.TWITCH,
+                    onClick = { onSelectService(VideoServiceType.TWITCH) },
                 )
                 Text("Twitch")
             }
         }
 
-        // Search Mode Selection
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.spacedBy(8.dp),
-        ) {
-            FilterChip(
-                selected = searchMode == SearchMode.KEYWORD,
-                onClick = { onSearchModeChange(SearchMode.KEYWORD) },
-                label = { Text("Keyword Search") },
-            )
-            FilterChip(
-                selected = searchMode == SearchMode.CHANNEL_NAME,
-                onClick = { onSearchModeChange(SearchMode.CHANNEL_NAME) },
-                label = { Text("Channel Name") },
-            )
+        // Search Mode Selection (Only for YouTube)
+        if (selectedService == VideoServiceType.YOUTUBE) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                FilterChip(
+                    selected = searchMode == SearchMode.KEYWORD,
+                    onClick = { onSearchModeChange(SearchMode.KEYWORD) },
+                    label = { Text("Keyword Search") },
+                )
+                FilterChip(
+                    selected = searchMode == SearchMode.CHANNEL_NAME,
+                    onClick = { onSearchModeChange(SearchMode.CHANNEL_NAME) },
+                    label = { Text("Channel Name") },
+                )
+            }
         }
 
         // Search Field
@@ -159,9 +161,10 @@ fun VideoSearchContent(
             onValueChange = onInputTextChange,
             label = {
                 Text(
-                    when (searchMode) {
-                        SearchMode.KEYWORD -> "Search by keyword..."
-                        SearchMode.CHANNEL_NAME -> "Search by channel name..."
+                    when {
+                        selectedService == VideoServiceType.TWITCH -> "Search by channel name..."
+                        searchMode == SearchMode.KEYWORD -> "Search by keyword..."
+                        else -> "Search by channel name..."
                     },
                 )
             },

--- a/composeApp/src/commonMain/kotlin/org/example/project/feature/video_search/ui/VideoSearchScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/example/project/feature/video_search/ui/VideoSearchScreen.kt
@@ -35,7 +35,7 @@ fun VideoSearchScreen(
             hasMoreResults = uiState.searchNextPageToken != null,
             selectedDate = uiState.selectedDate,
             searchMode = uiState.searchMode,
-            selectedServices = uiState.selectedServices,
+            selectedService = uiState.selectedService,
             onInputTextChange = { text -> onIntent(VideoSearchIntent.UpdateInputText(text)) },
             onExecuteSearch = { onIntent(VideoSearchIntent.ExecuteSearch) },
             onSelectResult = { result -> onIntent(VideoSearchIntent.SelectSearchResult(result)) },
@@ -43,7 +43,7 @@ fun VideoSearchScreen(
             onClearError = { onIntent(VideoSearchIntent.ClearSearchError) },
             onDateChange = { date -> onIntent(VideoSearchIntent.ChangeSelectedDate(date)) },
             onSearchModeChange = { mode -> onIntent(VideoSearchIntent.ChangeSearchMode(mode)) },
-            onToggleService = { service -> onIntent(VideoSearchIntent.ToggleService(service)) },
+            onSelectService = { service -> onIntent(VideoSearchIntent.SelectService(service)) },
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(16.dp),

--- a/shared/src/commonMain/kotlin/org/example/project/data/datasource/TwitchSearchDataSource.kt
+++ b/shared/src/commonMain/kotlin/org/example/project/data/datasource/TwitchSearchDataSource.kt
@@ -1,0 +1,8 @@
+package org.example.project.data.datasource
+
+import org.example.project.data.model.TwitchSearchResponse
+import org.example.project.domain.model.SearchQuery
+
+interface TwitchSearchDataSource {
+    suspend fun searchVideos(searchQuery: SearchQuery): Result<TwitchSearchResponse>
+}

--- a/shared/src/commonMain/kotlin/org/example/project/data/datasource/TwitchSearchDataSourceImpl.kt
+++ b/shared/src/commonMain/kotlin/org/example/project/data/datasource/TwitchSearchDataSourceImpl.kt
@@ -1,0 +1,138 @@
+package org.example.project.data.datasource
+
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.request.get
+import io.ktor.client.request.header
+import io.ktor.client.request.parameter
+import kotlin.time.ExperimentalTime
+import org.exampl.project.BuildKonfig
+import org.example.project.data.model.TwitchSearchResponse
+import org.example.project.data.model.TwitchUserResponse
+import org.example.project.domain.model.SearchEventType
+import org.example.project.domain.model.SearchQuery
+
+class TwitchSearchDataSourceImpl(
+    private val httpClient: HttpClient,
+) : TwitchSearchDataSource {
+
+    companion object {
+        private const val TWITCH_API_BASE_URL = "https://api.twitch.tv/helix"
+        private const val TWITCH_USERS_ENDPOINT = "$TWITCH_API_BASE_URL/search/channels"
+        private const val TWITCH_VIDEOS_ENDPOINT = "$TWITCH_API_BASE_URL/videos"
+    }
+
+    /**
+     * Get Twitch user ID from login name.
+     * Calls the /users endpoint to convert login name to user ID.
+     *
+     * @param login The user's login name (e.g., "shroud")
+     * @return The user's ID (e.g., "37402112"), or null if not found
+     */
+    private suspend fun getUserIdByLogin(query: String): String? {
+        return try {
+            val response = httpClient.get(TWITCH_USERS_ENDPOINT) {
+                header("Client-ID", BuildKonfig.TWITCH_CLIENT_ID)
+                header("Authorization", "Bearer ${BuildKonfig.TWITCH_API_KEY}")
+                parameter("query", query)
+            }
+
+            val userResponse: TwitchUserResponse = response.body()
+
+            // Check for API error response
+            if (!userResponse.error.isNullOrBlank()) {
+                return null
+            }
+
+            // Return the first user's ID, or null if no users found
+            userResponse.data.firstOrNull()?.id
+        } catch (e: Exception) {
+            null
+        }
+    }
+
+    @OptIn(ExperimentalTime::class)
+    override suspend fun searchVideos(searchQuery: SearchQuery): Result<TwitchSearchResponse> {
+        return try {
+            if (BuildKonfig.TWITCH_CLIENT_ID.isBlank() || BuildKonfig.TWITCH_API_KEY.isBlank()) {
+                return Result.failure(IllegalStateException("Twitch API credentials are not configured"))
+            }
+
+            // Note: Twitch Helix API doesn't have a direct video search endpoint like YouTube.
+            // The /videos endpoint requires user_id or game_id as a filter.
+            // We first need to get the user_id from the user's login name using /users endpoint.
+
+            // Try to extract a user login from the query if it looks like a channel name
+            val userLogin = searchQuery.query
+
+            if (userLogin.isBlank()) {
+                // Twitch doesn't support free-text video search without a user_id
+                return Result.success(
+                    TwitchSearchResponse(
+                        data = emptyList(),
+                        pagination = null,
+                    ),
+                )
+            }
+
+            // Step 1: Get user_id from login name using /users endpoint
+            val userId = getUserIdByLogin(userLogin)
+
+            if (userId == null) {
+                // User not found, return empty results
+                return Result.success(
+                    TwitchSearchResponse(
+                        data = emptyList(),
+                        pagination = null,
+                    ),
+                )
+            }
+
+            // Step 2: Get videos using the user_id
+            val response = httpClient.get(TWITCH_VIDEOS_ENDPOINT) {
+                header("Client-ID", BuildKonfig.TWITCH_CLIENT_ID)
+                header("Authorization", "Bearer ${BuildKonfig.TWITCH_API_KEY}")
+
+                // Add query parameters - use user_id instead of user_login
+                parameter("user_id", userId)
+                parameter("first", searchQuery.maxResults.coerceIn(1, 100))
+
+                // Map SearchEventType to Twitch video type
+                when (searchQuery.eventType) {
+                    SearchEventType.COMPLETED -> parameter("type", "archive")
+                    SearchEventType.LIVE -> {
+                        // Twitch /videos doesn't return live streams, only VODs
+                        // For live streams, we'd need to use /streams endpoint
+                    }
+                    else -> {
+                        // Default to archive (completed streams)
+                        parameter("type", "archive")
+                    }
+                }
+
+                // Add pagination token if provided
+                searchQuery.pageToken?.let { pageToken ->
+                    parameter("after", pageToken)
+                }
+
+                // Note: Twitch API doesn't have direct equivalents for YouTube's publishedAfter/Before
+                // These would need to be filtered client-side if needed
+            }
+
+            val apiResponse: TwitchSearchResponse = response.body()
+
+            // Check for API error response
+            if (!apiResponse.error.isNullOrBlank()) {
+                return Result.failure(
+                    RuntimeException("Twitch API error: ${apiResponse.error} - ${apiResponse.message ?: "Unknown error"}"),
+                )
+            }
+
+            Result.success(apiResponse)
+        } catch (e: Exception) {
+            Result.failure(
+                RuntimeException("Failed to search Twitch videos for query '${searchQuery.query}': ${e.message}", e),
+            )
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/org/example/project/data/mapper/TwitchSearchMapper.kt
+++ b/shared/src/commonMain/kotlin/org/example/project/data/mapper/TwitchSearchMapper.kt
@@ -1,0 +1,50 @@
+package org.example.project.data.mapper
+
+import kotlin.time.ExperimentalTime
+import kotlin.time.Instant
+import org.example.project.data.model.TwitchSearchResponse
+import org.example.project.domain.model.SearchResponse
+import org.example.project.domain.model.SearchResult
+
+object TwitchSearchMapper {
+
+    @OptIn(ExperimentalTime::class)
+    fun mapToSearchResponse(apiResponse: TwitchSearchResponse): SearchResponse {
+        val results = apiResponse.data.map { item ->
+            SearchResult(
+                videoId = item.id,
+                title = item.title,
+                description = item.description,
+                thumbnailUrl = formatThumbnailUrl(item.thumbnailUrl),
+                channelTitle = item.userName,
+                publishedAt = parseInstant(item.publishedAt),
+                isLiveBroadcast = item.type == "live", // VODs are typically not live
+            )
+        }
+
+        return SearchResponse(
+            results = results,
+            nextPageToken = apiResponse.pagination?.cursor,
+            totalResults = results.size, // Twitch doesn't provide total count
+        )
+    }
+
+    /**
+     * Formats Twitch thumbnail URL by replacing template parameters.
+     * Twitch thumbnail URLs come as templates like: "https://example.com/%{width}x%{height}.jpg"
+     */
+    private fun formatThumbnailUrl(templateUrl: String): String {
+        return templateUrl
+            .replace("%{width}", "320")
+            .replace("%{height}", "180")
+    }
+
+    @OptIn(ExperimentalTime::class)
+    private fun parseInstant(dateString: String): Instant {
+        return try {
+            Instant.parse(dateString)
+        } catch (e: Exception) {
+            Instant.DISTANT_PAST
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/org/example/project/data/model/TwitchSearchResponse.kt
+++ b/shared/src/commonMain/kotlin/org/example/project/data/model/TwitchSearchResponse.kt
@@ -1,0 +1,81 @@
+package org.example.project.data.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Response from Twitch Helix API videos search endpoint.
+ * Used for searching VODs (Video on Demand) on Twitch.
+ */
+@Serializable
+data class TwitchSearchResponse(
+    @SerialName("data")
+    val data: List<TwitchSearchItem> = emptyList(),
+
+    @SerialName("pagination")
+    val pagination: TwitchPagination? = null,
+
+    @SerialName("error")
+    val error: String? = null,
+
+    @SerialName("message")
+    val message: String? = null,
+
+    @SerialName("status")
+    val status: Int? = null,
+)
+
+/**
+ * Individual video item from Twitch search response.
+ * Represents a VOD (archived stream) result.
+ */
+@Serializable
+data class TwitchSearchItem(
+    @SerialName("id")
+    val id: String,
+
+    @SerialName("stream_id")
+    val streamId: String? = null,
+
+    @SerialName("user_id")
+    val userId: String,
+
+    @SerialName("user_login")
+    val userLogin: String,
+
+    @SerialName("user_name")
+    val userName: String,
+
+    @SerialName("title")
+    val title: String,
+
+    @SerialName("description")
+    val description: String,
+
+    @SerialName("created_at")
+    val createdAt: String,
+
+    @SerialName("published_at")
+    val publishedAt: String,
+
+    @SerialName("url")
+    val url: String,
+
+    @SerialName("thumbnail_url")
+    val thumbnailUrl: String,
+
+    @SerialName("viewable")
+    val viewable: String,
+
+    @SerialName("view_count")
+    val viewCount: Int,
+
+    @SerialName("language")
+    val language: String,
+
+    @SerialName("type")
+    val type: String, // "upload", "archive", "highlight"
+
+    @SerialName("duration")
+    val duration: String, // Format: "1h2m3s"
+)

--- a/shared/src/commonMain/kotlin/org/example/project/data/model/TwitchUserResponse.kt
+++ b/shared/src/commonMain/kotlin/org/example/project/data/model/TwitchUserResponse.kt
@@ -1,0 +1,35 @@
+package org.example.project.data.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Response from Twitch Helix API users endpoint.
+ * Used to get user information by login name or user ID.
+ */
+@Serializable
+data class TwitchUserResponse(
+    @SerialName("data")
+    val data: List<TwitchUser> = emptyList(),
+
+    @SerialName("error")
+    val error: String? = null,
+
+    @SerialName("message")
+    val message: String? = null,
+
+    @SerialName("status")
+    val status: Int? = null,
+)
+
+/**
+ * Twitch user information from the users endpoint.
+ */
+@Serializable
+data class TwitchUser(
+    @SerialName("id")
+    val id: String,
+
+    @SerialName("display_name")
+    val displayName: String,
+)

--- a/shared/src/commonMain/kotlin/org/example/project/data/repository/VideoSearchRepositoryImpl.kt
+++ b/shared/src/commonMain/kotlin/org/example/project/data/repository/VideoSearchRepositoryImpl.kt
@@ -4,7 +4,9 @@ import kotlin.time.ExperimentalTime
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
+import org.example.project.data.datasource.TwitchSearchDataSource
 import org.example.project.data.datasource.YouTubeSearchDataSource
+import org.example.project.data.mapper.TwitchSearchMapper
 import org.example.project.data.mapper.YouTubeSearchMapper
 import org.example.project.domain.model.SearchOrder
 import org.example.project.domain.model.SearchQuery
@@ -15,6 +17,7 @@ import org.example.project.domain.repository.VideoSearchRepository
 
 class VideoSearchRepositoryImpl(
     private val youTubeSearchDataSource: YouTubeSearchDataSource,
+    private val twitchSearchDataSource: TwitchSearchDataSource,
 ) : VideoSearchRepository {
 
     @OptIn(ExperimentalTime::class)
@@ -75,14 +78,12 @@ class VideoSearchRepositoryImpl(
                     }
             }
             VideoServiceType.TWITCH -> {
-                // TODO: Implement Twitch search when TwitchSearchDataSource is ready
-                Result.success(
-                    SearchResponse(
-                        results = emptyList(),
-                        totalResults = 0,
-                        servicePageTokens = mapOf(VideoServiceType.TWITCH to null),
-                    ),
-                )
+                twitchSearchDataSource.searchVideos(searchQuery)
+                    .map { apiResponse ->
+                        TwitchSearchMapper.mapToSearchResponse(apiResponse).copy(
+                            servicePageTokens = mapOf(VideoServiceType.TWITCH to apiResponse.pagination?.cursor),
+                        )
+                    }
             }
         }
     }

--- a/shared/src/commonMain/kotlin/org/example/project/di/SharedModule.kt
+++ b/shared/src/commonMain/kotlin/org/example/project/di/SharedModule.kt
@@ -1,5 +1,7 @@
 package org.example.project.di
 
+import org.example.project.data.datasource.TwitchSearchDataSource
+import org.example.project.data.datasource.TwitchSearchDataSourceImpl
 import org.example.project.data.datasource.YouTubeSearchDataSource
 import org.example.project.data.datasource.YouTubeSearchDataSourceImpl
 import org.example.project.data.repository.VideoSearchRepositoryImpl
@@ -24,12 +26,16 @@ val sharedModule = module {
     }
 
     single<VideoSearchRepository> {
-        VideoSearchRepositoryImpl(get())
+        VideoSearchRepositoryImpl(get(), get())
     }
 
     // Data source bindings
     single<YouTubeSearchDataSource> {
         YouTubeSearchDataSourceImpl(get())
+    }
+
+    single<TwitchSearchDataSource> {
+        TwitchSearchDataSourceImpl(get())
     }
 
     // Use case bindings


### PR DESCRIPTION
## 概要

Twitch Helix APIを統合し、チャンネル名による動画検索機能を実装しました。これにより、YouTubeに加えてTwitchのVOD（アーカイブ動画）も検索できるようになります。

## やったこと

### データレイヤー
- `TwitchSearchDataSource` インターフェースと実装クラスを追加
- Twitch Helix APIを使用した2段階検索フロー（チャンネル名 → ユーザーID → 動画）を実装
- Twitch API レスポンスモデル（`TwitchSearchResponse`, `TwitchUserResponse`）を追加
- `TwitchSearchMapper` でAPIレスポンスをドメインモデルに変換
- `VideoSearchRepository` にTwitch検索機能を統合
- `SharedModule` での依存関係注入設定

### UI/UX変更
- サービス選択を複数選択（チェックボックス）から単一選択（ラジオボタン）に変更
- Twitch選択時は検索モードを強制的に「チャンネル名」に設定
- Twitch選択時は検索モード切り替えUIを非表示（チャンネル検索のみ対応）
- 選択サービスに応じた検索フィールドのプレースホルダー表示
- デフォルト検索日を昨日に変更（VOD検索により適した設定）

### ViewModel更新
- `ToggleService` インテントを `SelectService` にリネーム
- 状態を `selectedServices: Set` から `selectedService` （単一選択）に変更
- Twitch検索時の `channelId` パラメータ処理を追加
- Twitch選択時に自動的に「チャンネル名」モードに切り替え

## やらないこと

- Twitchのライブストリーム検索（現在はVODのみ対応）
- 複数サービスの同時検索機能（将来的な拡張として保留）
- Twitch APIの日付フィルタリング（APIの制限によりクライアント側での対応が必要）

## 影響範囲

- **video_search** 機能全体に影響
- サービス選択UIが単一選択に変更されるため、既存の動作が変更される
- デフォルト検索日が「今日」から「昨日」に変更

## テスト

### 動作確認項目
- [ ] YouTubeでのキーワード検索が正常に動作すること
- [ ] YouTubeでのチャンネル名検索が正常に動作すること
- [ ] Twitchでのチャンネル名検索が正常に動作すること
- [ ] Twitchのチャンネルが見つからない場合のエラーハンドリング
- [ ] ページネーション（次のページ読み込み）が正常に動作すること
- [ ] サービス切り替え時に検索モードが適切に変更されること
- [ ] Twitch API認証情報が未設定の場合のエラーハンドリング

### テスト方法
1. アプリを起動し、動画検索画面を開く
2. YouTube/Twitchのラジオボタンで切り替えを確認
3. Twitchを選択し、チャンネル名（例: "shroud"）で検索
4. 検索結果が表示されることを確認
5. YouTubeに戻し、キーワード/チャンネル名両方で検索可能なことを確認

## 備考

### Twitch APIの制約事項
- Twitch Helix APIの `/videos` エンドポイントは `user_id` が必須パラメータ
- そのため、まず `/search/channels` でチャンネル名からユーザーIDを取得する2段階検索を実装
- YouTubeのような自由なキーワード検索はTwitch APIではサポートされていない

### 設定が必要な環境変数
- `TWITCH_CLIENT_ID`: Twitch APIのクライアントID
- `TWITCH_API_KEY`: Twitch APIのアクセストークン

これらが未設定の場合、エラーメッセージが表示されます。

### 今後の拡張候補
- Twitchライブストリーム検索（`/streams` エンドポイント使用）
- クライアント側での日付フィルタリング実装
- 検索結果のソート順カスタマイズ

🤖 Generated with [Claude Code](https://claude.com/claude-code)