### PR TITLE
feat: Twitchチャンネル検索のリアルタイム候補表示機能

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/example/project/core/di/AppModule.kt
+++ b/composeApp/src/commonMain/kotlin/org/example/project/core/di/AppModule.kt
@@ -29,6 +29,7 @@ val appModule = module {
     viewModel {
         StreamerSearchViewModel(
             videoSearchUseCase = get(),
+            channelSearchUseCase = get(),
             savedStateHandle = get(),
         )
     }

--- a/composeApp/src/commonMain/kotlin/org/example/project/feature/streamer_search/StreamerSearchIntent.kt
+++ b/composeApp/src/commonMain/kotlin/org/example/project/feature/streamer_search/StreamerSearchIntent.kt
@@ -1,6 +1,7 @@
 package org.example.project.feature.streamer_search
 
 import kotlinx.datetime.LocalDate
+import org.example.project.domain.model.ChannelInfo
 import org.example.project.domain.model.SearchResult
 import org.example.project.domain.model.VideoServiceType
 import org.example.project.feature.video_search.SearchMode
@@ -17,4 +18,6 @@ sealed interface StreamerSearchIntent {
     data class ChangeSelectedDate(val date: LocalDate) : StreamerSearchIntent
     data class ChangeSearchMode(val mode: SearchMode) : StreamerSearchIntent
     data class SelectService(val service: VideoServiceType) : StreamerSearchIntent
+    data class SearchChannels(val query: String) : StreamerSearchIntent
+    data class SelectChannel(val channel: ChannelInfo) : StreamerSearchIntent
 }

--- a/composeApp/src/commonMain/kotlin/org/example/project/feature/streamer_search/StreamerSearchUiState.kt
+++ b/composeApp/src/commonMain/kotlin/org/example/project/feature/streamer_search/StreamerSearchUiState.kt
@@ -6,6 +6,7 @@ import kotlinx.datetime.LocalDate
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.minus
 import kotlinx.datetime.toLocalDateTime
+import org.example.project.domain.model.ChannelInfo
 import org.example.project.domain.model.SearchResult
 import org.example.project.domain.model.VideoServiceType
 import org.example.project.feature.video_search.SearchMode
@@ -28,4 +29,7 @@ constructor(
         .minus(1, DateTimeUnit.DAY),
     val channelSearchMode: SearchMode = SearchMode.CHANNEL_NAME,
     val selectedService: VideoServiceType = VideoServiceType.YOUTUBE,
+    val channelSuggestions: List<ChannelInfo> = emptyList(),
+    val isSearchingChannels: Boolean = false,
+    val selectedChannel: ChannelInfo? = null,
 )

--- a/composeApp/src/commonMain/kotlin/org/example/project/feature/streamer_search/StreamerSearchViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/example/project/feature/streamer_search/StreamerSearchViewModel.kt
@@ -4,6 +4,8 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import kotlin.time.ExperimentalTime
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
@@ -15,9 +17,11 @@ import kotlinx.datetime.LocalDate
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.atTime
 import kotlinx.datetime.toInstant
+import org.example.project.domain.model.ChannelInfo
 import org.example.project.domain.model.SearchOrder
 import org.example.project.domain.model.SearchResult
 import org.example.project.domain.model.VideoServiceType
+import org.example.project.domain.usecase.ChannelSearchUseCase
 import org.example.project.domain.usecase.VideoSearchUseCase
 import org.example.project.feature.video_search.SearchMode
 
@@ -26,10 +30,12 @@ import org.example.project.feature.video_search.SearchMode
  */
 class StreamerSearchViewModel(
     private val videoSearchUseCase: VideoSearchUseCase,
+    private val channelSearchUseCase: ChannelSearchUseCase,
     savedStateHandle: SavedStateHandle,
 ) : ViewModel() {
 
     private val searchMode: String = savedStateHandle.get<String>("searchMode") ?: "MAIN"
+    private var channelSearchJob: Job? = null
 
     private val _uiState = MutableStateFlow(
         StreamerSearchUiState(
@@ -52,6 +58,8 @@ class StreamerSearchViewModel(
             is StreamerSearchIntent.ChangeSelectedDate -> changeSelectedDate(intent.date)
             is StreamerSearchIntent.ChangeSearchMode -> changeSearchMode(intent.mode)
             is StreamerSearchIntent.SelectService -> selectService(intent.service)
+            is StreamerSearchIntent.SearchChannels -> searchChannelsDebounced(intent.query)
+            is StreamerSearchIntent.SelectChannel -> selectChannel(intent.channel)
         }
     }
 
@@ -217,7 +225,90 @@ class StreamerSearchViewModel(
         _uiState.value = _uiState.value.copy(
             selectedService = service,
             channelSearchMode = newSearchMode,
+            channelSuggestions = emptyList(),
+            selectedChannel = null,
         )
+    }
+
+    /**
+     * Search for channels with debouncing (500ms delay).
+     * Used for real-time channel suggestions as the user types.
+     */
+    private fun searchChannelsDebounced(query: String) {
+        // Cancel previous search job
+        channelSearchJob?.cancel()
+
+        // Clear suggestions if query is empty
+        if (query.isBlank()) {
+            _uiState.value = _uiState.value.copy(
+                channelSuggestions = emptyList(),
+                isSearchingChannels = false,
+            )
+            return
+        }
+
+        // Only search for Twitch channels
+        if (_uiState.value.selectedService != VideoServiceType.TWITCH) {
+            return
+        }
+
+        // Launch new debounced search
+        channelSearchJob = viewModelScope.launch {
+            delay(500) // Debounce delay
+            searchChannels(query)
+        }
+    }
+
+    /**
+     * Execute channel search immediately.
+     */
+    private fun searchChannels(query: String) {
+        _uiState.value = _uiState.value.copy(
+            isSearchingChannels = true,
+        )
+
+        viewModelScope.launch {
+            try {
+                val result = channelSearchUseCase.searchTwitchChannels(
+                    query = query,
+                    maxResults = 5,
+                )
+
+                result.fold(
+                    onSuccess = { channels ->
+                        _uiState.value = _uiState.value.copy(
+                            channelSuggestions = channels,
+                            isSearchingChannels = false,
+                        )
+                    },
+                    onFailure = { error ->
+                        _uiState.value = _uiState.value.copy(
+                            channelSuggestions = emptyList(),
+                            isSearchingChannels = false,
+                        )
+                    },
+                )
+            } catch (e: Exception) {
+                _uiState.value = _uiState.value.copy(
+                    channelSuggestions = emptyList(),
+                    isSearchingChannels = false,
+                )
+            }
+        }
+    }
+
+    /**
+     * Select a channel from the suggestions and immediately search for videos.
+     */
+    private fun selectChannel(channel: ChannelInfo) {
+        _uiState.value = _uiState.value.copy(
+            selectedChannel = channel,
+            inputText = channel.displayName,
+            channelSuggestions = emptyList(), // Close dropdown
+        )
+
+        // Immediately search for videos for this channel
+        searchStreamers(channel.displayName)
     }
 }
 

--- a/composeApp/src/commonMain/kotlin/org/example/project/feature/streamer_search/ui/StreamerSearchContent.kt
+++ b/composeApp/src/commonMain/kotlin/org/example/project/feature/streamer_search/ui/StreamerSearchContent.kt
@@ -1,5 +1,6 @@
 package org.example.project.feature.streamer_search.ui
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -34,6 +35,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
 import kotlinx.datetime.LocalDate
+import org.example.project.domain.model.ChannelInfo
 import org.example.project.domain.model.SearchResult
 import org.example.project.domain.model.VideoServiceType
 import org.example.project.feature.video_search.ui.SearchResultItem
@@ -52,12 +54,16 @@ fun StreamerSearchContent(
     hasMoreResults: Boolean,
     selectedDate: LocalDate,
     selectedService: VideoServiceType,
+    channelSuggestions: List<ChannelInfo>,
+    isSearchingChannels: Boolean,
     onInputTextChange: (String) -> Unit,
     onExecuteSearch: () -> Unit,
     onSelectResult: (SearchResult) -> Unit,
     onLoadMore: () -> Unit,
     onClearError: () -> Unit,
     onSelectService: (VideoServiceType) -> Unit,
+    onSearchChannels: (String) -> Unit,
+    onSelectChannel: (ChannelInfo) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val keyboardController = LocalSoftwareKeyboardController.current
@@ -102,45 +108,79 @@ fun StreamerSearchContent(
             }
         }
 
-        // Search Field
-        OutlinedTextField(
-            value = inputText,
-            onValueChange = onInputTextChange,
-            label = { Text("Search by channel name...") },
-            leadingIcon = {
-                Icon(
-                    imageVector = Icons.Default.Search,
-                    contentDescription = "Search",
-                )
-            },
-            trailingIcon = {
-                if (inputText.isNotEmpty()) {
-                    IconButton(
-                        onClick = {
-                            onExecuteSearch()
-                            keyboardController?.hide()
-                        },
-                    ) {
+        // Search Field with Dropdown
+        Box {
+            Column {
+                OutlinedTextField(
+                    value = inputText,
+                    onValueChange = { newText ->
+                        onInputTextChange(newText)
+                        // Trigger channel search for Twitch only
+                        if (selectedService == VideoServiceType.TWITCH) {
+                            onSearchChannels(newText)
+                        }
+                    },
+                    label = { Text("Search by channel name...") },
+                    leadingIcon = {
                         Icon(
                             imageVector = Icons.Default.Search,
-                            contentDescription = "Execute Search",
+                            contentDescription = "Search",
                         )
+                    },
+                    trailingIcon = {
+                        if (inputText.isNotEmpty()) {
+                            IconButton(
+                                onClick = {
+                                    onExecuteSearch()
+                                    keyboardController?.hide()
+                                },
+                            ) {
+                                Icon(
+                                    imageVector = Icons.Default.Search,
+                                    contentDescription = "Execute Search",
+                                )
+                            }
+                        }
+                    },
+                    keyboardOptions = KeyboardOptions(
+                        imeAction = ImeAction.Search,
+                    ),
+                    keyboardActions = KeyboardActions(
+                        onSearch = {
+                            if (inputText.isNotBlank()) {
+                                onExecuteSearch()
+                                keyboardController?.hide()
+                            }
+                        },
+                    ),
+                    modifier = Modifier.fillMaxWidth(),
+                )
+
+                // Channel Suggestions Dropdown (for Twitch only)
+                if (selectedService == VideoServiceType.TWITCH && channelSuggestions.isNotEmpty()) {
+                    Card(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(top = 4.dp),
+                        elevation = CardDefaults.cardElevation(defaultElevation = 4.dp),
+                    ) {
+                        LazyColumn(
+                            modifier = Modifier.height(200.dp),
+                        ) {
+                            items(channelSuggestions) { channel ->
+                                ChannelSuggestionItem(
+                                    channel = channel,
+                                    onSelect = {
+                                        onSelectChannel(channel)
+                                        keyboardController?.hide()
+                                    },
+                                )
+                            }
+                        }
                     }
                 }
-            },
-            keyboardOptions = KeyboardOptions(
-                imeAction = ImeAction.Search,
-            ),
-            keyboardActions = KeyboardActions(
-                onSearch = {
-                    if (inputText.isNotBlank()) {
-                        onExecuteSearch()
-                        keyboardController?.hide()
-                    }
-                },
-            ),
-            modifier = Modifier.fillMaxWidth(),
-        )
+            }
+        }
 
         // Error display
         searchError?.let { error ->
@@ -256,5 +296,39 @@ fun StreamerSearchContent(
         }
 
         Spacer(modifier = Modifier.height(16.dp))
+    }
+}
+
+/**
+ * Channel suggestion item for dropdown menu
+ */
+@Composable
+private fun ChannelSuggestionItem(
+    channel: ChannelInfo,
+    onSelect: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .clickable { onSelect() }
+            .padding(horizontal = 16.dp, vertical = 12.dp),
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = channel.displayName,
+                style = MaterialTheme.typography.bodyLarge,
+                fontWeight = FontWeight.Medium,
+            )
+            channel.gameName?.let { gameName ->
+                Text(
+                    text = gameName,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
     }
 }

--- a/composeApp/src/commonMain/kotlin/org/example/project/feature/streamer_search/ui/StreamerSearchScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/example/project/feature/streamer_search/ui/StreamerSearchScreen.kt
@@ -35,12 +35,16 @@ fun StreamerSearchScreen(
             hasMoreResults = uiState.searchNextPageToken != null,
             selectedDate = uiState.selectedDate,
             selectedService = uiState.selectedService,
+            channelSuggestions = uiState.channelSuggestions,
+            isSearchingChannels = uiState.isSearchingChannels,
             onInputTextChange = { text -> onIntent(StreamerSearchIntent.UpdateInputText(text)) },
             onExecuteSearch = { onIntent(StreamerSearchIntent.ExecuteSearch) },
             onSelectResult = { result -> onIntent(StreamerSearchIntent.SelectSearchResult(result)) },
             onLoadMore = { onIntent(StreamerSearchIntent.LoadMoreSearchResults) },
             onClearError = { onIntent(StreamerSearchIntent.ClearSearchError) },
             onSelectService = { service -> onIntent(StreamerSearchIntent.SelectService(service)) },
+            onSearchChannels = { query -> onIntent(StreamerSearchIntent.SearchChannels(query)) },
+            onSelectChannel = { channel -> onIntent(StreamerSearchIntent.SelectChannel(channel)) },
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(16.dp),

--- a/shared/src/commonMain/kotlin/org/example/project/data/datasource/TwitchSearchDataSource.kt
+++ b/shared/src/commonMain/kotlin/org/example/project/data/datasource/TwitchSearchDataSource.kt
@@ -1,8 +1,10 @@
 package org.example.project.data.datasource
 
 import org.example.project.data.model.TwitchSearchResponse
+import org.example.project.data.model.TwitchUserResponse
 import org.example.project.domain.model.SearchQuery
 
 interface TwitchSearchDataSource {
     suspend fun searchVideos(searchQuery: SearchQuery): Result<TwitchSearchResponse>
+    suspend fun searchChannels(query: String, maxResults: Int = 5): Result<TwitchUserResponse>
 }

--- a/shared/src/commonMain/kotlin/org/example/project/data/datasource/TwitchSearchDataSourceImpl.kt
+++ b/shared/src/commonMain/kotlin/org/example/project/data/datasource/TwitchSearchDataSourceImpl.kt
@@ -23,6 +23,44 @@ class TwitchSearchDataSourceImpl(
     }
 
     /**
+     * Search for channels by query.
+     * Calls the /search/channels endpoint to find matching channels.
+     *
+     * @param query The search query (e.g., "shroud")
+     * @param maxResults Maximum number of results to return (default: 5)
+     * @return TwitchUserResponse containing matching channels
+     */
+    override suspend fun searchChannels(query: String, maxResults: Int): Result<TwitchUserResponse> {
+        return try {
+            if (BuildKonfig.TWITCH_CLIENT_ID.isBlank() || BuildKonfig.TWITCH_API_KEY.isBlank()) {
+                return Result.failure(IllegalStateException("Twitch API credentials are not configured"))
+            }
+
+            val response = httpClient.get(TWITCH_USERS_ENDPOINT) {
+                header("Client-ID", BuildKonfig.TWITCH_CLIENT_ID)
+                header("Authorization", "Bearer ${BuildKonfig.TWITCH_API_KEY}")
+                parameter("query", query)
+                parameter("first", maxResults.coerceIn(1, 20))
+            }
+
+            val userResponse: TwitchUserResponse = response.body()
+
+            // Check for API error response
+            if (!userResponse.error.isNullOrBlank()) {
+                return Result.failure(
+                    RuntimeException("Twitch API error: ${userResponse.error} - ${userResponse.message ?: "Unknown error"}"),
+                )
+            }
+
+            Result.success(userResponse)
+        } catch (e: Exception) {
+            Result.failure(
+                RuntimeException("Failed to search Twitch channels for query '$query': ${e.message}", e),
+            )
+        }
+    }
+
+    /**
      * Get Twitch user ID from login name.
      * Calls the /users endpoint to convert login name to user ID.
      *
@@ -35,6 +73,7 @@ class TwitchSearchDataSourceImpl(
                 header("Client-ID", BuildKonfig.TWITCH_CLIENT_ID)
                 header("Authorization", "Bearer ${BuildKonfig.TWITCH_API_KEY}")
                 parameter("query", query)
+                parameter("first", 1)
             }
 
             val userResponse: TwitchUserResponse = response.body()

--- a/shared/src/commonMain/kotlin/org/example/project/data/mapper/TwitchChannelMapper.kt
+++ b/shared/src/commonMain/kotlin/org/example/project/data/mapper/TwitchChannelMapper.kt
@@ -1,0 +1,31 @@
+package org.example.project.data.mapper
+
+import org.example.project.data.model.TwitchUser
+import org.example.project.domain.model.ChannelInfo
+
+/**
+ * Mapper for converting Twitch API channel data to domain models
+ */
+object TwitchChannelMapper {
+
+    /**
+     * Converts a TwitchUser to ChannelInfo domain model
+     */
+    fun TwitchUser.toChannelInfo(): ChannelInfo {
+        return ChannelInfo(
+            id = id,
+            displayName = displayName,
+            thumbnailUrl = thumbnailUrl,
+            broadcasterLanguage = broadcasterLanguage,
+            gameId = gameId,
+            gameName = gameName,
+        )
+    }
+
+    /**
+     * Converts a list of TwitchUsers to a list of ChannelInfo domain models
+     */
+    fun List<TwitchUser>.toChannelInfoList(): List<ChannelInfo> {
+        return map { it.toChannelInfo() }
+    }
+}

--- a/shared/src/commonMain/kotlin/org/example/project/data/model/TwitchUserResponse.kt
+++ b/shared/src/commonMain/kotlin/org/example/project/data/model/TwitchUserResponse.kt
@@ -32,4 +32,16 @@ data class TwitchUser(
 
     @SerialName("display_name")
     val displayName: String,
+
+    @SerialName("thumbnail_url")
+    val thumbnailUrl: String? = null,
+
+    @SerialName("broadcaster_language")
+    val broadcasterLanguage: String? = null,
+
+    @SerialName("game_id")
+    val gameId: String? = null,
+
+    @SerialName("game_name")
+    val gameName: String? = null,
 )

--- a/shared/src/commonMain/kotlin/org/example/project/di/SharedModule.kt
+++ b/shared/src/commonMain/kotlin/org/example/project/di/SharedModule.kt
@@ -8,6 +8,7 @@ import org.example.project.data.repository.VideoSearchRepositoryImpl
 import org.example.project.data.repository.VideoSyncRepositoryImpl
 import org.example.project.domain.repository.VideoSearchRepository
 import org.example.project.domain.repository.VideoSyncRepository
+import org.example.project.domain.usecase.ChannelSearchUseCase
 import org.example.project.domain.usecase.VideoSearchUseCase
 import org.example.project.domain.usecase.VideoSyncUseCase
 import org.example.project.domain.usecase.VideoSyncUseCaseImpl
@@ -45,5 +46,9 @@ val sharedModule = module {
 
     single<VideoSearchUseCase> {
         VideoSearchUseCase(get())
+    }
+
+    single<ChannelSearchUseCase> {
+        ChannelSearchUseCase(get())
     }
 }

--- a/shared/src/commonMain/kotlin/org/example/project/domain/model/ChannelInfo.kt
+++ b/shared/src/commonMain/kotlin/org/example/project/domain/model/ChannelInfo.kt
@@ -1,0 +1,14 @@
+package org.example.project.domain.model
+
+/**
+ * Domain model for channel information.
+ * Used for displaying channel search suggestions.
+ */
+data class ChannelInfo(
+    val id: String,
+    val displayName: String,
+    val thumbnailUrl: String? = null,
+    val broadcasterLanguage: String? = null,
+    val gameId: String? = null,
+    val gameName: String? = null,
+)

--- a/shared/src/commonMain/kotlin/org/example/project/domain/usecase/ChannelSearchUseCase.kt
+++ b/shared/src/commonMain/kotlin/org/example/project/domain/usecase/ChannelSearchUseCase.kt
@@ -1,0 +1,37 @@
+package org.example.project.domain.usecase
+
+import org.example.project.data.datasource.TwitchSearchDataSource
+import org.example.project.data.mapper.TwitchChannelMapper.toChannelInfoList
+import org.example.project.domain.model.ChannelInfo
+
+/**
+ * Use case for searching Twitch channels.
+ * Returns a list of matching channels for display in search suggestions.
+ */
+class ChannelSearchUseCase(
+    private val twitchSearchDataSource: TwitchSearchDataSource,
+) {
+
+    /**
+     * Search for Twitch channels by query
+     *
+     * @param query The search query (channel name)
+     * @param maxResults Maximum number of results to return (default: 5)
+     * @return Result containing a list of matching channels
+     */
+    suspend fun searchTwitchChannels(
+        query: String,
+        maxResults: Int = 5,
+    ): Result<List<ChannelInfo>> {
+        if (query.isBlank()) {
+            return Result.failure(IllegalArgumentException("Search query cannot be empty"))
+        }
+
+        return twitchSearchDataSource.searchChannels(
+            query = query.trim(),
+            maxResults = maxResults.coerceIn(1, 20),
+        ).map { response ->
+            response.data.toChannelInfoList()
+        }
+    }
+}


### PR DESCRIPTION
## 概要
Twitchチャンネル検索のUXを改善し、ユーザーが入力するたびに最大5件のチャンネル候補をリアルタイムでドロップダウン表示する機能を実装しました。従来の「最初にヒットした1件のみ使用」から、「複数候補から選択」する方式に変更することで、似た名前のチャンネルが多い場合でも正確に目的のチャンネルを選択できるようになります。

## やったこと
### Domain層 (`shared/`)
- `ChannelInfo.kt`: チャンネル情報のドメインモデルを新規作成
- `ChannelSearchUseCase.kt`: Twitchチャンネル検索専用のUse Caseを実装
- `TwitchChannelMapper.kt`: TwitchUser → ChannelInfo への変換Mapperを追加

### Data層 (`shared/`)
- `TwitchUserResponse.kt`: サムネイル、言語、ゲーム情報フィールドを追加
- `TwitchSearchDataSource.kt`: `searchChannels()` メソッドを追加
- `TwitchSearchDataSourceImpl.kt`: 最大5件のチャンネル検索APIを実装

### Presentation層 (`composeApp/`)
- `StreamerSearchUiState.kt`: チャンネル候補リスト、検索状態、選択チャンネルを追加
- `StreamerSearchIntent.kt`: `SearchChannels` と `SelectChannel` Intentを追加
- `StreamerSearchViewModel.kt`: 
  - 500msデバウンス機能付きリアルタイムチャンネル検索を実装
  - チャンネル選択時に即座にvideo検索を自動実行
- `StreamerSearchContent.kt`: 
  - TextFieldにドロップダウンUIを追加
  - `ChannelSuggestionItem` コンポーネントを実装（チャンネル名 + プレイ中のゲーム表示）
- DI設定更新: `ChannelSearchUseCase` を注入

### 技術的な実装詳細
- デバウンス処理（500ms）により、ユーザーが入力を止めてから検索を実行
- Twitch専用機能（YouTubeでは非表示）
- チャンネル選択後、ドロップダウンを自動クローズしてvideo検索を即座に実行
- サービス切り替え時に候補と選択状態をクリア

## やらないこと
- YouTubeのチャンネル検索（Twitch専用機能として実装）
- チャンネルサムネイル画像の表示（APIレスポンスには含まれるが、UI実装は今回スコープ外）
- チャンネル詳細情報の表示（フォロワー数、配信スケジュールなど）

## 影響範囲
- **Twitch検索フロー**: 既存のvideo検索フローは変更なし、チャンネル選択プロセスが追加
- **YouTube検索**: 影響なし（既存の動作を維持）
- **UI層**: `StreamerSearchContent` のTextField周辺に新しいドロップダウンUIが追加
- **API呼び出し**: Twitch `/search/channels` エンドポイントへの新規呼び出しが追加（デバウンス制御あり）

## テスト
### 手動テスト
1. **基本フロー**:
   - Twitchサービスを選択
   - TextFieldに「shr」と入力
   - 500ms後に候補が表示されることを確認
   - 「shroud」などのチャンネルを選択
   - video検索が自動実行されることを確認

2. **エッジケース**:
   - 入力文字をクリアすると候補が消えることを確認
   - YouTubeサービスに切り替えるとドロップダウンが表示されないことを確認
   - 検索中に別の文字を入力すると前の検索がキャンセルされることを確認（デバウンス動作）

3. **ビルド確認**:
   - `./gradlew :shared:build`: ✅ 成功（iOS testの既存エラーは無関係）
   - `./gradlew :composeApp:compileDebugKotlinAndroid`: ✅ 成功

## 備考
- Clean Architectureに従い、Domain層・Data層・Presentation層を適切に分離
- MVI パターンを維持し、既存のアーキテクチャに整合
- Koin DIを使用した依存性注入を適切に実装
- Compose UIのベストプラクティスに従った実装（stateless/stateful分離）
- ktlintの警告はパッケージ名のアンダースコアに関する既存の問題で、今回の変更とは無関係

🤖 Generated with [Claude Code](https://claude.com/claude-code)