### PR TITLE
feat: US-1 ローカル永続化基盤 - Phase 1 仕様定義

### DIFF
--- a/shared/src/commonMain/kotlin/org/example/project/data/local/REQUIREMENTS.md
+++ b/shared/src/commonMain/kotlin/org/example/project/data/local/REQUIREMENTS.md
@@ -23,11 +23,19 @@
 
 ### 2.1 依存関係（gradle/libs.versions.toml）
 
+> **Note**: バージョンはPhase 2実装時に最新の安定版/互換版を確認してください。
+> 以下は参考バージョンです。
+
 ```toml
 [versions]
-room = "2.7.1"
-sqlite = "2.5.0"
-ksp = "2.2.20-1.0.32"
+# Room KMP: https://developer.android.com/jetpack/androidx/releases/room
+# Phase 2で最新KMP対応バージョンを確認（2.7.0-alpha系 or 安定版）
+room = "2.7.0-alpha03"
+# SQLite Bundled: https://developer.android.com/jetpack/androidx/releases/sqlite
+sqlite = "2.4.0"
+# KSP: Kotlinバージョンに対応（例: Kotlin 2.0.21 → ksp 2.0.21-1.0.27）
+# プロジェクトのKotlinバージョンに合わせて調整
+ksp = "2.0.21-1.0.27"
 
 [libraries]
 androidx-room-runtime = { module = "androidx.room:room-runtime", version.ref = "room" }
@@ -154,7 +162,7 @@ data class SavedChannelEntity(
     val channelId: String,
     val channelName: String,
     val channelIconUrl: String,
-    val serviceType: String  // "YOUTUBE" or "TWITCH"
+    val serviceType: VideoServiceType  // TypeConverterで変換
 )
 ```
 
@@ -181,6 +189,21 @@ interface SyncHistoryDao {
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insertChannels(channels: List<SavedChannelEntity>)
+
+    /**
+     * 履歴とチャンネルをアトミックに保存する。
+     *
+     * insert()とinsertChannels()を別々に呼ぶと不整合リスクがあるため、
+     * このトランザクションメソッドを使用することを推奨。
+     */
+    @Transaction
+    suspend fun insertHistoryWithChannels(
+        history: SyncHistoryEntity,
+        channels: List<SavedChannelEntity>
+    ) {
+        insert(history)
+        insertChannels(channels)
+    }
 
     @Transaction
     @Query("SELECT * FROM sync_history ORDER BY lastUsedAt DESC")
@@ -213,12 +236,19 @@ interface SyncHistoryDao {
 
 **Converters.kt**:
 ```kotlin
+import org.example.project.domain.model.VideoServiceType
+
 class Converters {
-    // Instant <-> Long変換が必要な場合に使用
-    // SyncHistoryEntityではLong直接使用のため不要だが、
-    // 将来の拡張に備えて配置場所を確保
+    @TypeConverter
+    fun fromServiceType(value: VideoServiceType): String = value.name
+
+    @TypeConverter
+    fun toServiceType(value: String): VideoServiceType = VideoServiceType.valueOf(value)
 }
 ```
+
+> **Note**: ドメイン層のVideoServiceType Enumを直接使用することで型安全性を確保。
+> 不正な文字列がデータベースに保存されるのを防ぎます。
 
 ### 2.7 Koin DI設定
 

--- a/shared/src/commonTest/kotlin/org/example/project/data/local/SyncHistoryDaoTest.kt
+++ b/shared/src/commonTest/kotlin/org/example/project/data/local/SyncHistoryDaoTest.kt
@@ -1,10 +1,6 @@
 package org.example.project.data.local
 
 import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertNotNull
-import kotlin.test.assertNull
-import kotlin.test.assertTrue
 
 /**
  * SyncHistoryDaoのテスト
@@ -61,6 +57,23 @@ class SyncHistoryDaoTest {
         // Arrange: SyncHistoryEntityとSavedChannelEntityリストを作成
         // Act: dao.insert(), dao.insertChannels()を呼び出し
         // Assert: getById()でchannelsが正しく関連付けられていることを確認
+    }
+
+    @Test
+    fun `insertHistoryWithChannels should save history and channels atomically`() {
+        // TODO: Phase 2で実装
+        // Arrange: 履歴とチャンネルリストを作成
+        // Act: dao.insertHistoryWithChannels(history, channels)を呼び出し
+        // Assert: 履歴とチャンネルの両方が正しく保存されていることを確認
+    }
+
+    @Test
+    fun `insertHistoryWithChannels should rollback on failure`() {
+        // TODO: Phase 2で実装（オプション）
+        // Arrange: 履歴とチャンネルを作成（チャンネルに不正データを含める）
+        // Act: dao.insertHistoryWithChannels()でエラーを発生させる
+        // Assert: トランザクションがロールバックされ、履歴も保存されていないこと
+        // Note: Room KMPでのトランザクションロールバック検証が可能な場合のみ実装
     }
 
     // ===================


### PR DESCRIPTION
## Phase 1: 仕様・インターフェース定義

### Story Issue
- #36 [Story] US-1: ローカル永続化基盤の導入

### Epic
- #35 [Epic] 同期チャンネル履歴保存機能

---

## 成果物

### 1. REQUIREMENTS.md（技術仕様）
`shared/src/commonMain/kotlin/org/example/project/data/local/REQUIREMENTS.md`

- **Section 1: 技術ストーリー** - 開発者として何ができるか
- **Section 2: 技術仕様** - Room KMP設定、Entity/DAO定義、プラットフォーム対応
- **Section 3: 検証方法** - ビルド成功、テスト成功条件

### 2. テスト骨格
`shared/src/commonTest/kotlin/org/example/project/data/local/SyncHistoryDaoTest.kt`

20個のテストケース骨格（Phase 2で実装）:
- Insert系テスト（3件）
- GetById系テスト（2件）
- Delete系テスト（2件）
- RecordUsage系テスト（2件）
- UpdateName系テスト（2件）
- Observe系テスト（5件）
- Edge Cases（2件）

---

## 技術選定サマリー

| 項目 | 選定 |
|------|------|
| データベース | Room KMP 2.7.x |
| SQLiteドライバ | BundledSQLiteDriver |
| KSPバージョン | 2.2.20-1.0.32 |
| 対象プラットフォーム | Android, iOS |

---

## Phase 2で実装予定

- [ ] Gradle依存関係追加（libs.versions.toml）
- [ ] KSP設定追加（shared/build.gradle.kts）
- [ ] AppDatabase実装（expect/actual）
- [ ] DatabaseBuilder実装（expect/actual）
- [ ] Entity実装（SyncHistoryEntity, SavedChannelEntity）
- [ ] DAO実装（SyncHistoryDao）
- [ ] Mapper実装（Entity ↔ Domain変換）
- [ ] Repository実装（SyncHistoryRepositoryImpl）
- [ ] DI設定（DatabaseModule）
- [ ] テスト実装（SyncHistoryDaoTest）

---

## 次のアクション

承認後、Phase 2（`/phase2`）でAI実装開始

---

🤖 Generated with [Claude Code](https://claude.ai/code)