### PR TITLE
feat: RevenueCat API KeyをBuildKonfig経由でGitHub Secretsから注入

### DIFF
--- a/.github/workflows/CompareScreenshot.yml
+++ b/.github/workflows/CompareScreenshot.yml
@@ -54,6 +54,8 @@ jobs:
           branch: ${{ github.event.pull_request.base.ref || 'main' }}
 
       - name: Compare screenshots
+        env:
+          REVENUECAT_PUBLIC_API_KEY: ${{ secrets.REVENUECAT_PUBLIC_API_KEY }}
         run: ./gradlew compareRoborazziDebug
 
       - name: Upload screenshot diff

--- a/.github/workflows/StoreScreenshot.yml
+++ b/.github/workflows/StoreScreenshot.yml
@@ -44,6 +44,8 @@ jobs:
         run: chmod +x gradlew
 
       - name: Record screenshots
+        env:
+          REVENUECAT_PUBLIC_API_KEY: ${{ secrets.REVENUECAT_PUBLIC_API_KEY }}
         run: ./gradlew recordRoborazziDebug
 
       - name: Upload screenshots

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,11 @@ jobs:
       run: chmod +x gradlew
 
     - name: Run tests
+      env:
+        REVENUECAT_PUBLIC_API_KEY: ${{ secrets.REVENUECAT_PUBLIC_API_KEY }}
       run: ./gradlew test --continue
 
     - name: Generate coverage reports
+      env:
+        REVENUECAT_PUBLIC_API_KEY: ${{ secrets.REVENUECAT_PUBLIC_API_KEY }}
       run: ./gradlew koverXmlReport koverHtmlReport

--- a/.github/workflows/ios-deploy-testflight.yml
+++ b/.github/workflows/ios-deploy-testflight.yml
@@ -63,6 +63,7 @@ jobs:
           APP_STORE_CONNECT_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
           APP_STORE_CONNECT_API_KEY_CONTENT: ${{ secrets.APP_STORE_CONNECT_API_KEY_CONTENT }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          REVENUECAT_PUBLIC_API_KEY: ${{ secrets.REVENUECAT_PUBLIC_API_KEY }}
         run: |
           # ビルド番号にgithub.run_numberを使用してTestFlight配信
           # setup_ci はFastfile内のbeta laneで自動実行される

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -1,3 +1,4 @@
+import com.codingfeline.buildkonfig.compiler.FieldSpec.Type.STRING
 import org.gradle.declarative.dsl.schema.FqName.Empty.packageName
 import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
@@ -107,12 +108,15 @@ ktlint {
     }
 }
 
-// BuildKonfig: APIキーをクライアントに含めない（ADR-005 Phase 2）
-// サーバーAPI経由でYouTube/Twitch APIを呼び出すため、クライアント側のAPIキー定義は不要
+// BuildKonfig: ビルド時に環境変数からAPIキーを注入（ADR-005）
+// CI環境ではGitHub Secrets経由、ローカルではプレースホルダーにフォールバック
 buildkonfig {
-    packageName = "org.exampl.project"
+    packageName = "org.example.project"
     defaultConfigs {
-        // 将来的に必要な定数があればここに追加
-        // 現在はサーバーAPI経由のため、APIキーは不要
+        buildConfigField(
+            STRING,
+            "REVENUECAT_API_KEY",
+            System.getenv("REVENUECAT_PUBLIC_API_KEY") ?: "placeholder_api_key",
+        )
     }
 }

--- a/shared/src/androidMain/kotlin/org/example/project/config/RevenueCatConfig.android.kt
+++ b/shared/src/androidMain/kotlin/org/example/project/config/RevenueCatConfig.android.kt
@@ -1,15 +1,16 @@
 package org.example.project.config
 
+import org.example.project.BuildKonfig
+
 /**
  * Android用RevenueCat APIキー提供。
  *
- * 開発時はプレースホルダー値を返す。
- * 本番環境では環境変数やBuildKonfigから取得する。
+ * BuildKonfig経由でビルド時に注入された値を返す。
+ * CI環境ではGitHub Secretsから、ローカル環境ではプレースホルダー値が使用される。
  *
  * Epic: サブスクリプション基盤
  * Story Issue: US-3（RevenueCat SDK統合）
  */
 actual fun getRevenueCatApiKey(): String {
-    // TODO: 本番環境では環境変数やBuildKonfigから取得
-    return "android_placeholder_api_key"
+    return BuildKonfig.REVENUECAT_API_KEY
 }

--- a/shared/src/iosMain/kotlin/org/example/project/config/RevenueCatConfig.ios.kt
+++ b/shared/src/iosMain/kotlin/org/example/project/config/RevenueCatConfig.ios.kt
@@ -1,15 +1,16 @@
 package org.example.project.config
 
+import org.example.project.BuildKonfig
+
 /**
  * iOS用RevenueCat APIキー提供。
  *
- * 開発時はプレースホルダー値を返す。
- * 本番環境では環境変数やBuildKonfigから取得する。
+ * BuildKonfig経由でビルド時に注入された値を返す。
+ * CI環境ではGitHub Secretsから、ローカル環境ではプレースホルダー値が使用される。
  *
  * Epic: サブスクリプション基盤
  * Story Issue: US-3（RevenueCat SDK統合）
  */
 actual fun getRevenueCatApiKey(): String {
-    // TODO: 本番環境では環境変数やBuildKonfigから取得
-    return "ios_placeholder_api_key"
+    return BuildKonfig.REVENUECAT_API_KEY
 }

--- a/shared/src/jvmMain/kotlin/org/example/project/config/RevenueCatConfig.jvm.kt
+++ b/shared/src/jvmMain/kotlin/org/example/project/config/RevenueCatConfig.jvm.kt
@@ -1,14 +1,16 @@
 package org.example.project.config
 
+import org.example.project.BuildKonfig
+
 /**
  * JVM用RevenueCat APIキー提供。
  *
- * RevenueCat KMP SDKはJVMに対応していないため、スタブ値を返す。
- * サーバーサイドではサブスクリプション機能は使用しないため問題ない。
+ * RevenueCat KMP SDKはJVMに対応していないため、
+ * BuildKonfigのデフォルト値（プレースホルダー）がそのまま使用される。
  *
  * Epic: サブスクリプション基盤
  * Story Issue: US-3（RevenueCat SDK統合）
  */
 actual fun getRevenueCatApiKey(): String {
-    return "jvm_stub_api_key"
+    return BuildKonfig.REVENUECAT_API_KEY
 }


### PR DESCRIPTION
## Summary
- サブスクリプション画面のcredentials issueを解決
- RevenueCat API Keyをプレースホルダーから BuildKonfig 経由の環境変数注入に変更
- CI/CDワークフロー（ci, TestFlight, スクリーンショット）に `REVENUECAT_PUBLIC_API_KEY` 環境変数を追加

## Changes
| ファイル | 変更内容 |
|---------|---------|
| `shared/build.gradle.kts` | BuildKonfig設定追加、packageNameタイポ修正 |
| `RevenueCatConfig.{android,ios,jvm}.kt` | `BuildKonfig.REVENUECAT_API_KEY` を参照 |
| `ci.yml` / `ios-deploy-testflight.yml` | `REVENUECAT_PUBLIC_API_KEY` env追加 |
| `CompareScreenshot.yml` / `StoreScreenshot.yml` | 同上 |

## Required manual setup
マージ後、GitHub リポジトリの **Settings > Secrets and variables > Actions** で以下を登録:
- `REVENUECAT_PUBLIC_API_KEY`: RevenueCat Test Store の Public API Key

## Test plan
- [ ] GitHub Secretsに `REVENUECAT_PUBLIC_API_KEY` を登録
- [ ] CIが正常に通ることを確認（フォールバック値でもビルド成功）
- [ ] アプリでサブスクリプション画面を開き、credentials issueが解消されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)